### PR TITLE
Introduce `nuxt-img` Cover component with imagor provider

### DIFF
--- a/components/AppCover.vue
+++ b/components/AppCover.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { cva, type VariantProps } from "class-variance-authority";
+
+const image = cva("w-full h-full", {
+  variants: {
+    fit: {
+      full: "object-cover",
+    },
+  },
+});
+
+const placeholder = cva([
+  "flex h-full w-full items-center justify-center text-center",
+  "bg-zinc-200 text-zinc-500",
+  "dark:bg-zinc-700 dark:text-zinc-400",
+  "font-kanit font-bold",
+  "p-6",
+  "aspect-[2/3]",
+]);
+
+type AppCoverProps = VariantProps<typeof image> &
+  VariantProps<typeof placeholder>;
+
+defineProps<{
+  entry: {
+    name: string;
+    image_url: string | null;
+  };
+  fit?: AppCoverProps["fit"];
+  sizes?: string;
+}>();
+</script>
+
+<template>
+  <nuxt-img
+    v-if="entry.image_url"
+    provider="imagor"
+    loading="lazy"
+    :placeholder="[20, 30, 10]"
+    :src="entry.image_url"
+    :class="image({ fit })"
+    :sizes="sizes"
+  />
+  <div v-else :class="placeholder()">{{ entry.name }}</div>
+</template>

--- a/components/AppCover.vue
+++ b/components/AppCover.vue
@@ -13,7 +13,7 @@ const placeholder = cva([
   "flex h-full w-full items-center justify-center text-center",
   "bg-zinc-200 text-zinc-500",
   "dark:bg-zinc-700 dark:text-zinc-400",
-  "font-kanit font-bold",
+  "font-bold",
   "p-6",
   "aspect-[2/3]",
 ]);

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,10 +5,21 @@ export default defineNuxtConfig({
     "@nuxt/image-edge",
     "nuxt-icon",
     "@vueuse/nuxt",
+    "@pinia/nuxt",
   ],
   // https://nuxt.com/docs/getting-started/installation#prerequisites
   typescript: {
     shim: false,
     typeCheck: true,
+  },
+  image: {
+    providers: {
+      imagor: {
+        provider: "~/providers/imagor",
+        options: {
+          baseURL: "https://apps.glhf.vn/imagor",
+        },
+      },
+    },
   },
 });

--- a/providers/imagor.ts
+++ b/providers/imagor.ts
@@ -1,0 +1,20 @@
+import { joinURL } from "ufo";
+import type { ProviderGetImage } from "@nuxt/image-edge";
+
+export const getImage: ProviderGetImage = (
+  src,
+  { modifiers = {}, baseURL } = {}
+) => {
+  let url = baseURL;
+  const { width, height, quality } = modifiers;
+
+  if (width || height) {
+    url = joinURL(url, `/${width || 0}x${height || 0}`);
+  }
+
+  url = joinURL(url, `/filters:quality(${quality || 80})`);
+
+  return {
+    url: joinURL(url, src),
+  };
+};


### PR DESCRIPTION
## Describe your changes

- imagor provider was added with support for `width`, `height` and `quality` parameters of `nuxt-img` component
- `AppCover` component was added for loading book covers, as with support for falling-back to text