### PR TITLE
Introduce transition on tooltip display

### DIFF
--- a/components/BaseTooltip.vue
+++ b/components/BaseTooltip.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { createPopper } from "@popperjs/core";
+import { TransitionRoot } from "@headlessui/vue";
 
 const content = ref();
 const tooltip = ref();
@@ -11,6 +12,14 @@ let hideTooltip: () => void;
 onMounted(() => {
   const instance = createPopper(content.value, tooltip.value, {
     placement: "right-start",
+    modifiers: [
+      {
+        name: "offset",
+        options: {
+          offset: [0, 24],
+        },
+      },
+    ],
   });
 
   showTooltip = () => {
@@ -28,7 +37,17 @@ onMounted(() => {
   <div ref="content" @mouseenter="showTooltip" @mouseleave="hideTooltip">
     <slot name="main" />
   </div>
-  <div ref="tooltip" role="tooltip" :class="show ? 'block' : 'hidden'">
-    <slot name="popover" />
+  <div ref="tooltip" class="z-10" role="tooltip">
+    <TransitionRoot
+      :show="show"
+      enter="transition-opacity duration-75"
+      enter-from="opacity-0"
+      enter-to="opacity-100"
+      leave="transition-opacity duration-150"
+      leave-from="opacity-100"
+      leave-to="opacity-0"
+    >
+      <slot name="popover" />
+    </TransitionRoot>
   </div>
 </template>


### PR DESCRIPTION
## Describe your changes
Transition were added using `@headlessui/vue`'s `TransitionRoot` to `BaseTooltip` component, now modified with `popper-js` offset