### PR TITLE
Introduce MonthPicker component 

### DIFF
--- a/components/AppButton.vue
+++ b/components/AppButton.vue
@@ -14,7 +14,7 @@ const button = cva(
         success: ["bg-green-200", "hover:bg-green-300"],
         error: ["bg-red-200", "hover:bg-red-300"],
         caution: ["bg-orange-200", "hover:bg-orange-300"],
-        none: ["hover:bg-zinc-100 dark:hover:bg-zinc-700"],
+        none: "",
       },
     },
     defaultVariants: {

--- a/components/AppMonthPicker.vue
+++ b/components/AppMonthPicker.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { DateTime, Info, type MonthNumbers } from "luxon";
+import { createPopper } from "@popperjs/core";
+import {
+  Popover,
+  PopoverButton,
+  PopoverPanel,
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from "@headlessui/vue";
+
+interface MonthYear {
+  month: MonthNumbers;
+  year: number;
+}
+
+const props = defineProps<{
+  monthYear: MonthYear;
+}>();
+
+const button = ref();
+const popover = ref();
+
+const selectedYear = ref(props.monthYear.year);
+const selectedMonth = ref<MonthNumbers>(props.monthYear.month);
+
+const availableYears = [
+  ...Array.from(
+    { length: DateTime.now().year - 2021 + 2 }, // get from 2021 + the year after that
+    (_, index) => 2021 + index
+  ),
+];
+
+onMounted(() => {
+  createPopper(button.value, popover.value, {
+    placement: "bottom-start",
+    modifiers: [
+      {
+        name: "offset",
+        options: {
+          offset: [0, 12],
+        },
+      },
+    ],
+  });
+});
+
+defineEmits<{
+  (e: "updateMonthYear", monthYear: MonthYear): void;
+}>();
+</script>
+
+<template>
+  <Popover v-slot="{ open }" class="relative inline-block">
+    <div ref="button">
+      <PopoverButton
+        class="font-kanit flex items-center gap-3 rounded-2xl bg-zinc-200 py-1 px-2 text-2xl font-bold transition-all duration-150 ease-linear hover:bg-zinc-300 dark:bg-zinc-700 dark:hover:bg-zinc-600"
+      >
+        {{ monthYear.month }}/{{ monthYear.year }}
+        <Icon
+          name="bi:chevron-down"
+          :class="[{ 'rotate-180': open }, 'text-base transition-transform']"
+        />
+      </PopoverButton>
+    </div>
+
+    <div ref="popover" class="z-10">
+      <transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="-translate-y-2 opacity-0"
+        enter-to-class="translate-y-0 opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="translate-y-0 opacity-100"
+        leave-to-class="translate-y-1 opacity-0"
+      >
+        <PopoverPanel
+          v-slot="{ close }"
+          class="w-max max-w-xs overflow-hidden rounded-2xl bg-zinc-100 shadow-lg dark:bg-zinc-700"
+        >
+          <div class="space-y-3 p-3">
+            <Listbox v-model="selectedYear">
+              <ListboxButton
+                class="relative w-full rounded-xl bg-zinc-200 py-1 px-2 text-lg font-bold transition-all duration-300 hover:bg-zinc-300 dark:bg-zinc-600 dark:hover:bg-zinc-500"
+              >
+                {{ selectedYear }}
+                <span class="absolute inset-y-0 right-2 flex items-center">
+                  <Icon name="bi:chevron-bar-expand" />
+                </span>
+              </ListboxButton>
+              <transition
+                enter-active-class="transition duration-100 ease-out"
+                enter-from-class="transform scale-95 opacity-0"
+                enter-to-class="transform scale-100 opacity-100"
+                leave-active-class="transition duration-75 ease-out"
+                leave-from-class="transform scale-100 opacity-100"
+                leave-to-class="transform scale-95 opacity-0"
+              >
+                <ListboxOptions
+                  class="absolute inset-x-3 mt-3 max-h-40 overflow-auto rounded-xl bg-zinc-200 dark:bg-zinc-600"
+                >
+                  <ListboxOption
+                    v-for="availableYear in availableYears"
+                    v-slot="{ active, selected }"
+                    :key="availableYear"
+                    :value="availableYear"
+                    as="template"
+                  >
+                    <li
+                      :class="[
+                        {
+                          'bg-zinc-300 dark:bg-zinc-500': active,
+                          'font-bold': selected,
+                        },
+                        'relative w-full cursor-default py-1 px-2 text-center transition-colors',
+                      ]"
+                    >
+                      <span
+                        class="absolute inset-y-0 right-2 flex items-center"
+                      >
+                        <Icon v-if="selected" name="bi:check" />
+                      </span>
+                      {{ availableYear }}
+                    </li>
+                  </ListboxOption>
+                </ListboxOptions>
+              </transition>
+            </Listbox>
+
+            <div class="grid grid-cols-3 gap-1">
+              <AppButton
+                v-for="monthNumber in Info.months('numeric')"
+                :key="monthNumber"
+                :class="[
+                  {
+                    'bg-primary text-zinc-50':
+                      parseInt(monthNumber) == selectedMonth,
+                    'hover:bg-zinc-200 dark:hover:bg-zinc-600':
+                      parseInt(monthNumber) != selectedMonth,
+                  },
+                ]"
+                @click="
+                  {
+                    selectedMonth = parseInt(monthNumber) as MonthNumbers;
+                  }
+                "
+              >
+                Tháng {{ monthNumber }}
+              </AppButton>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3">
+              <AppButton
+                @click="
+                  {
+                    selectedMonth = DateTime.now().month;
+                    selectedYear = DateTime.now().year;
+                  }
+                "
+                >Tháng này</AppButton
+              >
+              <AppButton
+                :intent="
+                  selectedMonth == monthYear.month &&
+                  selectedYear == monthYear.year
+                    ? 'secondary'
+                    : 'primary'
+                "
+                @click="
+                  {
+                    $emit('updateMonthYear', {
+                      month: selectedMonth,
+                      year: selectedYear,
+                    });
+                    close();
+                  }
+                "
+              >
+                Áp dụng
+              </AppButton>
+            </div>
+          </div>
+        </PopoverPanel>
+      </transition>
+    </div>
+  </Popover>
+</template>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@nuxt/image-edge": "1.0.0-27968280.9739e4d",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@nuxtjs/tailwindcss": "^6.4.1",
+    "@types/luxon": "^3.2.0",
     "@types/node": "^18.14.6",
     "@vueuse/core": "^9.13.0",
     "@vueuse/nuxt": "^9.13.0",
@@ -40,6 +41,7 @@
     "@pinia/nuxt": "^0.4.7",
     "@popperjs/core": "^2.11.6",
     "class-variance-authority": "^0.4.0",
+    "luxon": "^3.3.0",
     "pinia": "^2.0.33"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   '@nuxtjs/tailwindcss': ^6.4.1
   '@pinia/nuxt': ^0.4.7
   '@popperjs/core': ^2.11.6
+  '@types/luxon': ^3.2.0
   '@types/node': ^18.14.6
   '@vueuse/core': ^9.13.0
   '@vueuse/nuxt': ^9.13.0
@@ -17,6 +18,7 @@ specifiers:
   eslint-config-prettier: ^8.6.0
   husky: ^8.0.3
   lint-staged: ^13.1.2
+  luxon: ^3.3.0
   nuxt: ^3.2.3
   nuxt-icon: ^0.3.2
   pinia: ^2.0.33
@@ -30,6 +32,7 @@ dependencies:
   '@pinia/nuxt': 0.4.7_typescript@4.9.5
   '@popperjs/core': 2.11.6
   class-variance-authority: 0.4.0_typescript@4.9.5
+  luxon: 3.3.0
   pinia: 2.0.33_typescript@4.9.5
 
 devDependencies:
@@ -38,6 +41,7 @@ devDependencies:
   '@nuxt/image-edge': 1.0.0-27968280.9739e4d
   '@nuxtjs/eslint-config-typescript': 12.0.0_ycpbpc6yetojsgtrx3mwntkhsu
   '@nuxtjs/tailwindcss': 6.4.1
+  '@types/luxon': 3.2.0
   '@types/node': 18.14.6
   '@vueuse/core': 9.13.0
   '@vueuse/nuxt': 9.13.0_nuxt@3.2.3
@@ -1974,6 +1978,10 @@ packages:
 
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/luxon/3.2.0:
+    resolution: {integrity: sha512-lGmaGFoaXHuOLXFvuju2bfvZRqxAqkHPx9Y9IQdQABrinJJshJwfNCKV+u7rR3kJbiqfTF/NhOkcxxAFrObyaA==}
     dev: true
 
   /@types/minimist/1.2.2:
@@ -5798,6 +5806,11 @@ packages:
     resolution: {integrity: sha512-8/HcIENyQnfUTCDizRu9rrDyG6XG/21M4X7/YEGZeD76ZJilFPAUVb/2zysFf7VVO1LEjCDFyHp8pMMvozIrvg==}
     engines: {node: '>=12'}
     dev: true
+
+  /luxon/3.3.0:
+    resolution: {integrity: sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /magic-string/0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from "tailwindcss";
+
+export default <Partial<Config>>{
+  theme: {
+    screens: {
+      sm: "640px",
+      // => @media (min-width: 640px) { ... }
+      md: "768px",
+      // => @media (min-width: 768px) { ... }
+      lg: "1024px",
+      // => @media (min-width: 1024px) { ... }
+      xl: "1280px",
+      // => @media (min-width: 1280px) { ... }
+    },
+    extend: {
+      colors: {
+        primary: "#f8b60b",
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Describe your changes
MonthPicker component as issue #8 were introduced, as with some changes:
- hover style of `none` intent of `AppButton` were removed
- added `luxon` package for working with date-time
- `tailwind.config.ts` were introduced with primary color - to be change later on

## Usage
`<AppMonthPicker />` could now be called with the following properties:
- `:month-year` binding
- `@update-month-year` emit - on pressing apply

Example usage:
```vue
<script setup lang="ts">
import { DateTime, type MonthNumbers } from "luxon";

// MonthNumbers type of `luxon` only allows number from 1-12
const month = ref<MonthNumbers>(DateTime.now().month);
const year = ref(DateTime.now().year);
</script>

<template>
  <AppMonthPicker
    :month-year="{ month, year }"
    @update-month-year="
      (dateObj) => {
        year = dateObj.year;
        month = dateObj.month;
      }
    "
  />
</template>
```

## Future improvements
- i18n could be improve, as of now only support hard-coded Vietnamese

## Behavior
https://user-images.githubusercontent.com/12823486/225507560-b0f6c7c5-82bb-4cd7-b41d-6520a1cc4d3a.mov