### PR TITLE
Force `AppCover` to display with fixed 2/3 aspect ratio

### DIFF
--- a/components/AppCover.vue
+++ b/components/AppCover.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { cva, type VariantProps } from "class-variance-authority";
 
-const image = cva("w-full h-full aspect-[2/3]", {
+const image = cva("w-full h-full aspect-[2/3] object-cover", {
   variants: {
     fit: {
       full: "object-cover",

--- a/components/AppCover.vue
+++ b/components/AppCover.vue
@@ -1,32 +1,9 @@
 <script setup lang="ts">
-import { cva, type VariantProps } from "class-variance-authority";
-
-const image = cva("w-full h-full aspect-[2/3] object-cover", {
-  variants: {
-    fit: {
-      full: "object-cover",
-    },
-  },
-});
-
-const placeholder = cva([
-  "flex h-full w-full items-center justify-center text-center",
-  "bg-zinc-200 text-zinc-500",
-  "dark:bg-zinc-700 dark:text-zinc-400",
-  "font-bold",
-  "p-6",
-  "aspect-[2/3]",
-]);
-
-type AppCoverProps = VariantProps<typeof image> &
-  VariantProps<typeof placeholder>;
-
 defineProps<{
   entry: {
     name: string;
     image_url: string | null;
   };
-  fit?: AppCoverProps["fit"];
   sizes?: string;
 }>();
 </script>
@@ -36,10 +13,22 @@ defineProps<{
     v-if="entry.image_url"
     provider="imagor"
     loading="lazy"
+    class="aspect-[2/3] h-full w-full object-cover"
     :placeholder="[20, 30, 10]"
     :src="entry.image_url"
-    :class="image({ fit })"
     :sizes="sizes"
   />
-  <div v-else :class="placeholder()">{{ entry.name }}</div>
+  <div
+    v-else
+    :class="[
+      'flex h-full w-full items-center justify-center text-center',
+      'bg-zinc-200 text-zinc-500',
+      'dark:bg-zinc-700 dark:text-zinc-400',
+      'font-bold',
+      'p-6',
+      'aspect-[2/3]',
+    ]"
+  >
+    {{ entry.name }}
+  </div>
 </template>

--- a/components/AppCover.vue
+++ b/components/AppCover.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { cva, type VariantProps } from "class-variance-authority";
 
-const image = cva("w-full h-full", {
+const image = cva("w-full h-full aspect-[2/3]", {
   variants: {
     fit: {
       full: "object-cover",


### PR DESCRIPTION
## Describe your changes
- Force `AppCover` component - which used to display title cover and fallback if no image is found, to display with fixed `aspect-ratio: 2/3`.
- Remove unused `cva` dependencies from component

<details><summary>Comparison</summary>
<p>
Old design:
<img width="1260" alt="image" src="https://user-images.githubusercontent.com/12823486/226522799-452c7c10-4128-4b71-9a54-91bb49b52085.png">

After implementing this PR:
<img width="1262" alt="image" src="https://user-images.githubusercontent.com/12823486/226522859-6e663bb9-57d2-4fc6-9da0-6666a0a59b21.png">

</p>
</details> 