### PR TITLE
Introduce Inter and Lexend as fonts, with `@nuxtjs/google-fonts` module installed 

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -6,6 +6,7 @@ export default defineNuxtConfig({
     "nuxt-icon",
     "@vueuse/nuxt",
     "@pinia/nuxt",
+    "@nuxtjs/google-fonts",
   ],
   // https://nuxt.com/docs/getting-started/installation#prerequisites
   typescript: {
@@ -20,6 +21,12 @@ export default defineNuxtConfig({
           baseURL: "https://apps.glhf.vn/imagor",
         },
       },
+    },
+  },
+  googleFonts: {
+    families: {
+      Inter: [400, 700],
+      Lexend: [700, 900],
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@commitlint/config-conventional": "^17.4.4",
     "@nuxt/image-edge": "1.0.0-27968280.9739e4d",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
+    "@nuxtjs/google-fonts": "^3.0.0",
     "@nuxtjs/tailwindcss": "^6.4.1",
     "@tailwindcss/forms": "^0.5.3",
     "@types/luxon": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ specifiers:
   '@headlessui/vue': ^1.7.12
   '@nuxt/image-edge': 1.0.0-27968280.9739e4d
   '@nuxtjs/eslint-config-typescript': ^12.0.0
+  '@nuxtjs/google-fonts': ^3.0.0
   '@nuxtjs/tailwindcss': ^6.4.1
   '@pinia/nuxt': ^0.4.7
   '@popperjs/core': ^2.11.6
@@ -41,6 +42,7 @@ devDependencies:
   '@commitlint/config-conventional': 17.4.4
   '@nuxt/image-edge': 1.0.0-27968280.9739e4d
   '@nuxtjs/eslint-config-typescript': 12.0.0_byynos7ffx3cepxtk6gvolkky4
+  '@nuxtjs/google-fonts': 3.0.0
   '@nuxtjs/tailwindcss': 6.4.1
   '@tailwindcss/forms': 0.5.3
   '@types/luxon': 3.2.0
@@ -1720,6 +1722,17 @@ packages:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
+      - supports-color
+    dev: true
+
+  /@nuxtjs/google-fonts/3.0.0:
+    resolution: {integrity: sha512-knP2CJFkMHGQ9pepVNwquXvqiIHDma/6yZNXiYk7WWatRbbQUPf2423vXiBYu267Mff2KMuDLoAJ1Dsv2ymhdQ==}
+    dependencies:
+      '@nuxt/kit': 3.2.3
+      google-fonts-helper: 3.2.4
+      pathe: 1.1.0
+    transitivePeerDependencies:
+      - rollup
       - supports-color
     dev: true
 
@@ -4792,6 +4805,15 @@ packages:
 
   /globrex/0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: true
+
+  /google-fonts-helper/3.2.4:
+    resolution: {integrity: sha512-M740UjqBOxmG2qFUW7Lhgak9WDpsT18zxLJuG+MP4r+G1vhqbWm3x3D40xFEzhveQAneaEr8WjPxf+vcx9Xohg==}
+    dependencies:
+      deepmerge: 4.3.0
+      hookable: 5.4.2
+      ofetch: 1.0.1
+      ufo: 1.1.1
     dev: true
 
   /gopd/1.0.1:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import defaultTheme from "tailwindcss/defaultTheme";
 
 export default <Partial<Config>>{
   theme: {
@@ -15,6 +16,10 @@ export default <Partial<Config>>{
     extend: {
       colors: {
         primary: "#f8b60b",
+      },
+      fontFamily: {
+        sans: ["Inter", ...defaultTheme.fontFamily.sans],
+        lexend: "Lexend",
       },
     },
   },


### PR DESCRIPTION
## Describe your changes
- `@nuxtjs/google-fonts` module was installed
- [Inter](https://fonts.google.com/specimen/Inter) was introduced as primary font, with [Lexend](https://fonts.google.com/specimen/Lexend) as secondary and can be applied using `.font-lexend` class 