### PR TITLE
Introduce default layout and auth pages

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,19 @@
 <template>
-  <div>
-    <NuxtWelcome />
+  <div class="bg-zinc-100 text-zinc-800 dark:bg-zinc-800 dark:text-zinc-100">
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
   </div>
 </template>
+
+<style>
+.page-enter-active,
+.page-leave-active {
+  transition: all 0.4s;
+}
+.page-enter-from,
+.page-leave-to {
+  opacity: 0;
+  filter: blur(1rem);
+}
+</style>

--- a/layouts/auth.vue
+++ b/layouts/auth.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <TheNavigation position="fixed" />
+    <main class="container mx-auto px-3">
+      <slot />
+    </main>
+    <TheSearch />
+  </div>
+</template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>
+    <TheNavigation />
+    <main class="container mx-auto px-3">
+      <slot />
+    </main>
+    <TheSearch />
+  </div>
+</template>

--- a/pages/forget.vue
+++ b/pages/forget.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="flex h-screen items-center justify-center">
+    <div
+      class="w-full min-w-fit max-w-sm rounded-lg bg-zinc-200 p-6 dark:bg-zinc-700"
+    >
+      <h2 class="font-lexend mb-6 text-4xl font-bold">Quên mật khẩu</h2>
+      <form class="space-y-3">
+        <div class="space-y-1">
+          <label class="block" for="email">Email</label>
+          <input
+            id="email"
+            class="focus:ring-primary w-full rounded-xl border-none bg-zinc-300 transition-all invalid:ring-2 invalid:ring-red-400 focus:bg-zinc-100 focus:ring-2 dark:bg-zinc-600 focus:dark:bg-zinc-700"
+            type="email"
+            placeholder="konnichiwa@glhf.vn"
+          />
+        </div>
+        <AppButton class="w-full" intent="primary">Yêu cầu</AppButton>
+        <div class="text-center text-zinc-600 dark:text-zinc-400">
+          <NuxtLink
+            class="decoration-primary decoration-2 hover:underline"
+            to="/login"
+            >Đăng nhập</NuxtLink
+          >
+          &middot;
+          <NuxtLink
+            class="decoration-primary decoration-2 hover:underline"
+            to="/register"
+            >Đăng ký</NuxtLink
+          >
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="flex h-screen items-center justify-center">
+    <div
+      class="w-full min-w-fit max-w-sm rounded-lg bg-zinc-200 p-6 dark:bg-zinc-700"
+    >
+      <h2 class="font-lexend mb-6 text-4xl font-bold">Đăng nhập</h2>
+      <form class="space-y-3">
+        <div class="space-y-1">
+          <label class="block" for="email">Email</label>
+          <input
+            id="email"
+            class="focus:ring-primary w-full rounded-xl border-none bg-zinc-300 transition-all invalid:ring-2 invalid:ring-red-400 focus:bg-zinc-100 focus:ring-2 dark:bg-zinc-600 focus:dark:bg-zinc-700"
+            type="email"
+            placeholder="konnichiwa@glhf.vn"
+          />
+        </div>
+        <div class="space-y-1">
+          <label class="block" for="password">Mật khẩu</label>
+          <input
+            id="password"
+            class="focus:ring-primary w-full rounded-xl border-none bg-zinc-300 transition-all focus:bg-zinc-100 focus:ring-2 dark:bg-zinc-600 focus:dark:bg-zinc-700"
+            type="password"
+            placeholder="dotdotdot"
+          />
+        </div>
+        <div class="flex items-center gap-3">
+          <input
+            id="remember"
+            type="checkbox"
+            class="text-primary focus:ring-primary rounded bg-transparent transition-all focus:ring-2"
+          />
+          <label for="remember">Lưu đăng nhập</label>
+        </div>
+        <AppButton class="w-full" intent="primary">Đăng nhập</AppButton>
+        <div class="text-center text-zinc-600 dark:text-zinc-400">
+          <NuxtLink
+            class="decoration-primary decoration-2 hover:underline"
+            to="/forget"
+            >Quên mật khẩu?</NuxtLink
+          >
+          &middot;
+          <NuxtLink
+            class="decoration-primary decoration-2 hover:underline"
+            to="/register"
+            >Đăng ký</NuxtLink
+          >
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="flex h-screen items-center justify-center">
+    <div
+      class="w-full min-w-fit max-w-sm rounded-lg bg-zinc-200 p-6 dark:bg-zinc-700"
+    >
+      <h2 class="font-lexend mb-6 text-4xl font-bold">Đăng nhập</h2>
+      <form class="space-y-3">
+        <div class="space-y-1">
+          <label class="block" for="username">Tên tài khoản</label>
+          <input
+            id="username"
+            class="focus:ring-primary w-full rounded-xl border-none bg-zinc-300 transition-all invalid:ring-2 invalid:ring-red-400 focus:bg-zinc-100 focus:ring-2 dark:bg-zinc-600 focus:dark:bg-zinc-700"
+            type="text"
+            placeholder="kikuri"
+          />
+        </div>
+        <div class="space-y-1">
+          <label class="block" for="email">Email</label>
+          <input
+            id="email"
+            class="focus:ring-primary w-full rounded-xl border-none bg-zinc-300 transition-all invalid:ring-2 invalid:ring-red-400 focus:bg-zinc-100 focus:ring-2 dark:bg-zinc-600 focus:dark:bg-zinc-700"
+            type="email"
+            placeholder="konnichiwa@glhf.vn"
+          />
+        </div>
+        <div class="space-y-1">
+          <label class="block" for="password">Mật khẩu</label>
+          <input
+            id="password"
+            class="focus:ring-primary w-full rounded-xl border-none bg-zinc-300 transition-all focus:bg-zinc-100 focus:ring-2 dark:bg-zinc-600 focus:dark:bg-zinc-700"
+            type="password"
+            placeholder="dotdotdot"
+          />
+        </div>
+        <AppButton class="w-full" intent="primary">Đăng ký</AppButton>
+        <div class="text-center text-zinc-600 dark:text-zinc-400">
+          <NuxtLink
+            class="decoration-primary decoration-2 hover:underline"
+            to="/login"
+            >Đăng nhập</NuxtLink
+          >
+        </div>
+      </form>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Describe your changes
- `default.vue` layout has been added with search capability
- `auth.vue` layout has been added as single-screen page with no scroll
- Three new barebone auth pages has been introduced: `/login`, `/register` and `/forget` with no form handling as of now.